### PR TITLE
After adding course, no longer scrolls

### DIFF
--- a/client/src/components/CourseList.js
+++ b/client/src/components/CourseList.js
@@ -30,6 +30,13 @@ class CourseList extends React.Component {
     componentDidMount() {
         this.deptLastScrolledTo = this.deptToScrollTo
     }
+
+    shouldComponentUpdate(nextProps,nextState) {
+        var menuUpdated =  nextProps.menus !== this.props.menus
+        var deptUpdated = nextProps.search_query_dept !== this.props.search_query_dept
+        var numUpdated = nextProps.search_query_num !== this.props.search_query_num
+        return menuUpdated || deptUpdated || numUpdated
+    }
     
     componentDidUpdate() {
         // For a department match or partial match


### PR DESCRIPTION
CourseList now only refreshes if the correct props update.  Previously the addCourse prop function was triggering it.

Issues still not fixed:
Scrolling manually can mess with the list's sense of position sometimes.  For example, type "CSE", then scroll a bit down, then add " 1"